### PR TITLE
fix: div tag instead of a

### DIFF
--- a/css/skills.css
+++ b/css/skills.css
@@ -63,7 +63,7 @@
     padding: 0 20px;
 }
 
-.container-data-skill a{
+.container-data-skill div{
     font-weight: 300;
     transition: .3s;
     text-align: left;
@@ -71,12 +71,13 @@
     font-size: 18px;
 }
 
-.container-data-skill a i{
+.container-data-skill div i{
     float: right;
 }
 
-.container-data-skill a:hover{
+.container-data-skill div:hover{
     transform: scale(1.1);
+    cursor: pointer;
 }
 
 @media (max-width: 968px){

--- a/index.html
+++ b/index.html
@@ -170,10 +170,10 @@
                 <div class="container-title-skill">
                     <h3>- Desarrollo Front End -</h3>
                     <div class="container-data-skill">
-                        <a href="#">HTML <i class="fab fa-html5"></i></a>
-                        <a href="#">CSS <i class="fab fa-css3-alt"></i></a>
-                        <a href="#">JavaScript <i class="fab fa-js"></i></a>
-                        <a href="#">React <i class="fab fa-react"></i></a>
+                        <div>HTML <i class="fab fa-html5"></i></div>
+                        <div>CSS <i class="fab fa-css3-alt"></i></div>
+                        <div>JavaScript <i class="fab fa-js"></i></div>
+                        <div>React <i class="fab fa-react"></i></div>
                     </div>
                 </div>
             </div>
@@ -184,8 +184,8 @@
                 <div class="container-title-skill">
                     <h3>- Control de Versiones -</h3>
                     <div class="container-data-skill">
-                        <a href="#">Git <i class="fab fa-git"></i></a>
-                        <a href="#">GitHub <i class="fab fa-github"></i></a>
+                        <div>Git <i class="fab fa-git"></i></div>
+                        <div>GitHub <i class="fab fa-github"></i></div>
                     </div>
                 </div>
             </div>
@@ -196,8 +196,8 @@
                 <div class="container-title-skill">
                     <h3>- Idiomas -</h3>
                     <div class="container-data-skill">
-                        <a href="#">Ingles </a>
-                        <a href="#">Español </a>
+                        <div>Ingles </div>
+                        <div>Español </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Problema
Al dar click en cualquiera de los items en la sección `Habilidades` te envía a la parte superior de la página.

## Propuesta de solución
Para evitar esto se modificó la etiqueta `div` por `a` y se modificaron los estilos para ser aplicados a esta nueva etiqueta.
Tambien se agregó `cursor: pointer` para modificar el cursor, esto solo en caso de que la intención original haya sido tener esa finalidad.